### PR TITLE
Publishing installation via pacstall

### DIFF
--- a/src/desktop/index.md.hbs
+++ b/src/desktop/index.md.hbs
@@ -81,3 +81,9 @@ SchildiChat can be installed from a community repository. The package works only
 su -c "urpmi.addmedia --distrib https://mageialinux-online.org/repository/8/$(arch)"
 su -c "urpmi schildichat-desktop"
 ```
+
+#### Pacstall <small>(e.g. Debian, Ubuntu, ...)</small>
+SchildiChat can be installed from a community AUR-like repository, [Pacstall](https://pacstall.dev/) with [package](https://pacstall.dev/packages/schildichat-deb).
+```
+pacstall -I schildichat-deb
+```


### PR DESCRIPTION
As requested, an example of how to install the package using Pacstall has been added.

The package is not yet published on pacstall, as we were waiting for your release.

I will be requesting its publication shortly after this PR.

<https://github.com/SchildiChat/schildichat-desktop/issues/194>
<https://github.com/pacstall/pacstall-programs/pull/3661>